### PR TITLE
Add drop items action to order management

### DIFF
--- a/src/main/java/org/nexus/leDatOrder/listeners/OrderListener.java
+++ b/src/main/java/org/nexus/leDatOrder/listeners/OrderListener.java
@@ -187,6 +187,12 @@ public class OrderListener implements Listener {
             if (slot == collectSlot && clicked.getType() == collectMat) {
                 OrderManageGUI.collectItems(plugin, player);
             }
+
+            int dropSlot = plugin.getConfigManager().getItemSlot("gui.order-manage.drop-item", 15);
+            Material dropMat = plugin.getConfigManager().getItemMaterial("gui.order-manage.drop-item", Material.HOPPER);
+            if (slot == dropSlot && clicked.getType() == dropMat) {
+                OrderManageGUI.dropItems(plugin, player);
+            }
             return;
         }
 

--- a/src/main/java/org/nexus/leDatOrder/managers/ConfigManager.java
+++ b/src/main/java/org/nexus/leDatOrder/managers/ConfigManager.java
@@ -289,6 +289,13 @@ public class ConfigManager {
             config.set(basePath + ".order.collect.completed", "&aĐơn hàng đã hoàn thành và được xóa khỏi hệ thống.");
         }
 
+        if (!config.contains(basePath + ".order.drop.none")) {
+            config.set(basePath + ".order.drop.none", "&cNo delivered items available to drop.");
+        }
+        if (!config.contains(basePath + ".order.drop.success")) {
+            config.set(basePath + ".order.drop.success", "&aĐã thả &e%amount% %material% &axuống đất.");
+        }
+
         if (!config.contains(basePath + ".order.completed-owner")) {
             config.set(basePath + ".order.completed-owner", "&aĐơn hàng %material% đã hoàn thành và được xóa khỏi hệ thống!");
         }
@@ -507,9 +514,10 @@ public class ConfigManager {
         if (!config.contains(basePath + ".order-info-item.slot")) {
             config.set(basePath + ".order-info-item.slot", 13);
         }
-        
+
         setDefaultItem(basePath + ".cancel-item", "BARRIER", "&cCancel Order", 12, Arrays.asList("&7Click to cancel this order"));
         setDefaultItem(basePath + ".collect-item", "CHEST", "&aCollect Items", 14, Arrays.asList("&7Click to collect delivered items", "&7Available: &e%received%"));
+        setDefaultItem(basePath + ".drop-item", "HOPPER", "&eDrop Items", 15, Arrays.asList("&7Drop delivered items to the ground", "&7Available: &e%received%"));
     }
 
     private void setDefaultCreateOrderGUI() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,6 +40,9 @@ messages:
       partial: "&aĐã nhận &e%collected% %material%&a. Phần còn lại đã rơi xuống đất do túi đồ đầy."
       success: "&aĐã nhận &e%amount% %material%!"
       completed: "&aĐơn hàng đã hoàn thành và được xóa khỏi hệ thống."
+    drop:
+      none: "&cNo delivered items available to drop."
+      success: "&aĐã thả &e%amount% %material% &axuống đất."
     completed-owner: "&aĐơn hàng %material% đã hoàn thành và được xóa khỏi hệ thống!"
 
   # Currency Messages
@@ -203,6 +206,14 @@ gui:
         - "&7Click to collect delivered items"
         - "&7Available: &e%received%"
       slot: 14
+
+    drop-item:
+      material: HOPPER
+      display-name: "&eDrop Items"
+      lore:
+        - "&7Drop delivered items to the ground"
+        - "&7Available: &e%received%"
+      slot: 15
   
   # Create Order GUI
   create-order:


### PR DESCRIPTION
## Summary
- add configurable Drop Items button to the order management GUI
- implement safe dropping of all delivered items at the player's location
- provide configuration defaults and messages for the new drop action

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f648fc1548329b4b8c060344ad1dc)